### PR TITLE
Python packages: Add cmdline flags for macos, change crate names to fix build

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,5 @@
+[target.x86_64-apple-darwin]
+rustflags = [
+  "-C", "link-arg=-undefined",
+  "-C", "link-arg=dynamic_lookup",
+]

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ build-tiny:
 test:
 	cargo test
 
+# for macos, do
+# cp target/release/libreasonable.dylib reasonable/reasonable.so
+# this test is missing brick_inference_test.n3 so it doens't work 
 test-python:
 	cargo build --lib --release --features "python-library"
 	cp ./target/release/libreasonable.so reasonable/reasonable.so

--- a/src/python.rs
+++ b/src/python.rs
@@ -1,4 +1,4 @@
-use crate::owl;
+use crate::reasoner;
 use pyo3::exceptions;
 use pyo3::prelude::*;
 use pyo3::types::{PyList, PyTuple};
@@ -9,7 +9,7 @@ use rdf::uri::Uri;
 /// `PyReasoner` implements a reasoner for the OWL 2 RL profile (see
 /// https://www.w3.org/TR/owl2-profiles/#OWL_2_RL for details).
 struct PyReasoner {
-    reasoner: owl::Reasoner,
+    reasoner: reasoner::Reasoner,
 }
 
 #[pymethods]
@@ -18,7 +18,7 @@ impl PyReasoner {
     /// Creates a new PyReasoner object
     fn new() -> Self {
         PyReasoner {
-            reasoner: owl::Reasoner::new(),
+            reasoner: reasoner::Reasoner::new(),
         }
     }
 


### PR DESCRIPTION
I am just fumbling around with Rust so that this seems to work is as much dumb luck as anything that means I know what I'm doing, but I was able to run the test program from the README with these changes on MacOS. There may be a better way.

The crate changes to src/python.rs I think I required no matter what - without them, running 
`cargo build --lib --release --features "python-library"` 
fails on Linux (Ubuntu 18.04 VM) and MacOS

The addition to .cargo/config comes straight from the manual at https://pyo3.rs/v0.12.1/ 

I did not try anything with maturin so for all I know this blows all the pypi & wheel stuff up completely. 

I'm on the nightly toolchain
```
(reason) epaulson:~/development/reasonable $ rustc --version
rustc 1.49.0-nightly (b1af43bc6 2020-10-10)
(reason) epaulson:~/development/reasonable $ rustup toolchain list
stable-x86_64-apple-darwin (default)
nightly-x86_64-apple-darwin (override)
```
Reasonable (but not the python library) does build without these changes - if I just do a 'make build' I get an executable at the end in the target/release directory.