### PR TITLE
Implement scm-eqc1 and scm-eqc2 rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,13 @@ Using rule definitions from [here](https://www.w3.org/TR/owl2-profiles/#Reasonin
 | **yes**| `cax-dw` | throws exception      |
 | no     | `cax-adc` |  throws exception     |
 
+### Schema Vocabulary Semantics
+
+|Completed| Rule name | Notes |
+|---------|----------|-------|
+| **yes**| `scm-eqc1` | `owl:equivalentClass` → `rdfs:subClassOf` (one direction) |
+| **yes**| `scm-eqc2` | `owl:equivalentClass` → `rdfs:subClassOf` (other direction) |
+
 ### Other
 
 - no datatype semantics for now

--- a/README.md
+++ b/README.md
@@ -133,7 +133,13 @@ fn main() {
 
 Using rule definitions from [here](https://www.w3.org/TR/owl2-profiles/#Reasoning_in_OWL_2_RL_and_RDF_Graphs_using_Rules).
 
-**TODO**: implement RDF/RDFS entailment semantics as described [here](https://www.w3.org/TR/rdf11-mt/)
+**TODO**: implement remaining RDF/RDFS entailment semantics as described [here](https://www.w3.org/TR/rdf11-mt/)
+
+### RDFS Semantics
+
+|Completed| Rule name | Notes |
+|---------|----------|-------|
+| **yes**| `rdfs11` | `rdfs:subClassOf` transitivity |
 
 **Note**: haven't implemented rules that produce exceptions; waiting to determine the best way of handling these errors.
 

--- a/lib/src/reasoner.rs
+++ b/lib/src/reasoner.rs
@@ -789,6 +789,10 @@ impl Reasoner {
         //  T(?c1, ?x, rdf:type)
         let cax_sco_2 = self.iter1.variable::<(URI, URI)>("cax_sco_2");
 
+        // rdfs11 — rdfs:subClassOf transitivity
+        // T(?c1, rdfs:subClassOf, ?c2), T(?c2, rdfs:subClassOf, ?c3) => T(?c1, rdfs:subClassOf, ?c3)
+        let rdfs11_1 = self.iter1.variable::<(URI, URI)>("rdfs11_1");
+
         // cax-eqc1
         // T(?c1, owl:equivalentClass, ?c2), T(?x, rdf:type, ?c1)  =>
         //  T(?x, rdf:type, ?c2)
@@ -1128,6 +1132,16 @@ impl Reasoner {
                         //println!("instance: {:?} {:?} {:?}", self.to_u(inst), self.to_u(parent), self.to_u(class));
                         (inst, (rdftype_node, parent))
                     },
+                );
+
+                // rdfs11
+                // T(?c1, rdfs:subClassOf, ?c2), T(?c2, rdfs:subClassOf, ?c3)
+                //   => T(?c1, rdfs:subClassOf, ?c3)
+                rdfs11_1.from_map(&cax_sco_1, |&(c1, c2)| (c2, c1));
+                self.all_triples_input.from_join(
+                    &rdfs11_1,  // (c2, c1)
+                    &cax_sco_1, // (c2, c3)
+                    |&_c2, &c1, &c3| (c1, (rdfssubclass_node, c3)),
                 );
 
                 // cax-eqc1, cax-eqc2

--- a/lib/src/reasoner.rs
+++ b/lib/src/reasoner.rs
@@ -951,6 +951,16 @@ impl Reasoner {
                     &owl_equivalent_relation,
                     |&_, &(c1, c2), &()| (c2, c1),
                 );
+
+                // scm-eqc1 + scm-eqc2
+                // T(?c1, owl:equivalentClass, ?c2) => T(?c1, rdfs:subClassOf, ?c2)
+                // T(?c1, owl:equivalentClass, ?c2) => T(?c2, rdfs:subClassOf, ?c1)
+                // owl_equivalent_class already contains both directions, so one from_map suffices
+                self.all_triples_input.from_map(
+                    &owl_equivalent_class,
+                    |&(c1, c2)| (c1, (rdfssubclass_node, c2)),
+                );
+
                 symmetric_properties.from_join(
                     &self.rdf_type_inv.borrow(),
                     &owl_symprop_relation,

--- a/lib/src/tests.rs
+++ b/lib/src/tests.rs
@@ -923,6 +923,85 @@ fn test_cax_dw() -> Result<(), String> {
     Ok(())
 }
 
+#[test]
+fn test_rdfs11() -> Result<(), String> {
+    // Basic transitivity: A subClassOf B, B subClassOf C => A subClassOf C
+    let mut r = Reasoner::new();
+    let trips = vec![
+        ("urn:A", RDFS_SUBCLASSOF, "urn:B"),
+        ("urn:B", RDFS_SUBCLASSOF, "urn:C"),
+    ];
+    r.load_triples_str(trips);
+    r.reason();
+    let res = r.get_triples_string();
+    assert!(res.contains(&(
+        "<urn:A>".to_string(),
+        wrap!(RDFS_SUBCLASSOF),
+        "<urn:C>".to_string()
+    )));
+    Ok(())
+}
+
+#[test]
+fn test_rdfs11_long_chain() -> Result<(), String> {
+    // 4-level chain: A subClassOf B subClassOf C subClassOf D
+    let mut r = Reasoner::new();
+    let trips = vec![
+        ("urn:A", RDFS_SUBCLASSOF, "urn:B"),
+        ("urn:B", RDFS_SUBCLASSOF, "urn:C"),
+        ("urn:C", RDFS_SUBCLASSOF, "urn:D"),
+    ];
+    r.load_triples_str(trips);
+    r.reason();
+    let res = r.get_triples_string();
+    // A subClassOf C (one hop)
+    assert!(res.contains(&(
+        "<urn:A>".to_string(),
+        wrap!(RDFS_SUBCLASSOF),
+        "<urn:C>".to_string()
+    )));
+    // A subClassOf D (two hops)
+    assert!(res.contains(&(
+        "<urn:A>".to_string(),
+        wrap!(RDFS_SUBCLASSOF),
+        "<urn:D>".to_string()
+    )));
+    // B subClassOf D (one hop)
+    assert!(res.contains(&(
+        "<urn:B>".to_string(),
+        wrap!(RDFS_SUBCLASSOF),
+        "<urn:D>".to_string()
+    )));
+    Ok(())
+}
+
+#[test]
+fn test_rdfs11_with_instances() -> Result<(), String> {
+    // Transitivity + instance propagation together
+    let mut r = Reasoner::new();
+    let trips = vec![
+        ("urn:A", RDFS_SUBCLASSOF, "urn:B"),
+        ("urn:B", RDFS_SUBCLASSOF, "urn:C"),
+        ("urn:x", RDF_TYPE, "urn:A"),
+    ];
+    r.load_triples_str(trips);
+    r.reason();
+    let res = r.get_triples_string();
+    // TBox: A subClassOf C (rdfs11)
+    assert!(res.contains(&(
+        "<urn:A>".to_string(),
+        wrap!(RDFS_SUBCLASSOF),
+        "<urn:C>".to_string()
+    )));
+    // ABox: x rdf:type C (cax-sco)
+    assert!(res.contains(&(
+        "<urn:x>".to_string(),
+        wrap!(RDF_TYPE),
+        "<urn:C>".to_string()
+    )));
+    Ok(())
+}
+
 //#[test]
 //fn test_triple_update1() -> Result<(), String> {
 //    let mut u = TripleUpdate::new();

--- a/lib/src/tests.rs
+++ b/lib/src/tests.rs
@@ -1002,6 +1002,93 @@ fn test_rdfs11_with_instances() -> Result<(), String> {
     Ok(())
 }
 
+#[test]
+fn test_scm_eqc_basic() -> Result<(), String> {
+    // equivalentClass implies subClassOf in both directions
+    let mut r = Reasoner::new();
+    let trips = vec![("urn:A", OWL_EQUIVALENTCLASS, "urn:B")];
+    r.load_triples_str(trips);
+    r.reason();
+    let res = r.get_triples_string();
+    assert!(res.contains(&(
+        "<urn:A>".to_string(),
+        wrap!(RDFS_SUBCLASSOF),
+        "<urn:B>".to_string()
+    )));
+    assert!(res.contains(&(
+        "<urn:B>".to_string(),
+        wrap!(RDFS_SUBCLASSOF),
+        "<urn:A>".to_string()
+    )));
+    Ok(())
+}
+
+#[test]
+fn test_equivalentclass_transitivity() -> Result<(), String> {
+    // A eqClass B, B eqClass C
+    // => A subClassOf C and C subClassOf A (transitive via rdfs11)
+    let mut r = Reasoner::new();
+    let trips = vec![
+        ("urn:A", OWL_EQUIVALENTCLASS, "urn:B"),
+        ("urn:B", OWL_EQUIVALENTCLASS, "urn:C"),
+    ];
+    r.load_triples_str(trips);
+    r.reason();
+    let res = r.get_triples_string();
+    // A subClassOf C (via scm-eqc + rdfs11)
+    assert!(res.contains(&(
+        "<urn:A>".to_string(),
+        wrap!(RDFS_SUBCLASSOF),
+        "<urn:C>".to_string()
+    )));
+    // C subClassOf A (via scm-eqc + rdfs11)
+    assert!(res.contains(&(
+        "<urn:C>".to_string(),
+        wrap!(RDFS_SUBCLASSOF),
+        "<urn:A>".to_string()
+    )));
+    Ok(())
+}
+
+#[test]
+fn test_subclassof_through_equivalentclass() -> Result<(), String> {
+    // A eqClass B, C subClassOf B => C subClassOf A
+    let mut r = Reasoner::new();
+    let trips = vec![
+        ("urn:A", OWL_EQUIVALENTCLASS, "urn:B"),
+        ("urn:C", RDFS_SUBCLASSOF, "urn:B"),
+    ];
+    r.load_triples_str(trips);
+    r.reason();
+    let res = r.get_triples_string();
+    assert!(res.contains(&(
+        "<urn:C>".to_string(),
+        wrap!(RDFS_SUBCLASSOF),
+        "<urn:A>".to_string()
+    )));
+    Ok(())
+}
+
+#[test]
+fn test_scm_eqc_with_instances() -> Result<(), String> {
+    // A eqClass B, C subClassOf B, x rdf:type C => x rdf:type A
+    let mut r = Reasoner::new();
+    let trips = vec![
+        ("urn:A", OWL_EQUIVALENTCLASS, "urn:B"),
+        ("urn:C", RDFS_SUBCLASSOF, "urn:B"),
+        ("urn:x", RDF_TYPE, "urn:C"),
+    ];
+    r.load_triples_str(trips);
+    r.reason();
+    let res = r.get_triples_string();
+    assert!(res.contains(&(
+        "<urn:x>".to_string(),
+        wrap!(RDF_TYPE),
+        "<urn:A>".to_string()
+    )));
+    Ok(())
+}
+
 //#[test]
 //fn test_triple_update1() -> Result<(), String> {
 //    let mut u = TripleUpdate::new();


### PR DESCRIPTION
Addresses the second part of #39 (`scm-eqc1` and `scm-eqc1` rules)

Note that this PR depends on #40.