### PR TITLE
Add support for python graph update

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,24 @@ triples = r.reason()
 print("from files:", len(triples))
 ```
 
+#### Incremental Reasoning
+
+After the first `reason()` call, the reasoner supports incremental materialization. Use `update_graph()` to replace the base triples when your graph changes — the reasoner automatically diffs and selects incremental (additions only) or full re-materialization (if removals detected):
+
+```python
+r = reasonable.PyReasoner()
+r.from_graph(ontology + data)
+r.reason()                        # full materialization
+
+# data changes over time...
+data.add(new_triple)
+data.remove(old_triple)
+r.update_graph(ontology + data)   # replaces base, auto-detects diff
+r.reason()                        # incremental or full as needed
+```
+
+See the [Python README](python/README.md) for the full API reference.
+
 ### Rust
 
 See [Rust docs](https://docs.rs/reasonable)

--- a/lib/src/reasoner.rs
+++ b/lib/src/reasoner.rs
@@ -794,6 +794,91 @@ impl Reasoner {
         }
     }
 
+    /// Replaces the base triples entirely with the given set.
+    ///
+    /// Computes a diff against the current base:
+    /// - If only additions are detected, they are routed to the pending delta
+    ///   for incremental reasoning on the next `reason()` call.
+    /// - If any removals are detected, the reasoner state is reset via `clear()`
+    ///   so the next `reason()` call performs a full re-materialization.
+    ///
+    /// Returns `true` if removals were detected (full re-materialization needed),
+    /// `false` if only additions (or no change).
+    pub fn set_base_triples(&mut self, triples: Vec<Triple>) -> bool {
+        // Convert to keyed triples
+        let mut new_base: Vec<KeyedTriple> = Vec::with_capacity(triples.len() + 2);
+        for trip in triples.iter() {
+            let s = self.index.put(trip.subject.clone().into());
+            let p = self.index.put(trip.predicate.clone().into());
+            let o = self.index.put(trip.object.clone().into());
+            new_base.push((s, (p, o)));
+        }
+        // Always include seed triples (cls-thing, cls-nothing1)
+        let u_owl_class = self.index.put(owl!("Class"));
+        new_base.push((self.owlthing_node, (self.rdftype_node, u_owl_class)));
+        new_base.push((self.owlnothing_node, (self.rdftype_node, u_owl_class)));
+        new_base.sort_unstable();
+        new_base.dedup();
+
+        // Sort old base for diff
+        self.base.sort_unstable();
+
+        // Compute diff via linear merge of two sorted vecs
+        let mut added: Vec<KeyedTriple> = Vec::new();
+        let mut has_removals = false;
+        let (mut i, mut j) = (0, 0);
+        while i < self.base.len() && j < new_base.len() {
+            use std::cmp::Ordering;
+            match self.base[i].cmp(&new_base[j]) {
+                Ordering::Less => {
+                    // In old but not in new → removal
+                    has_removals = true;
+                    i += 1;
+                }
+                Ordering::Equal => {
+                    i += 1;
+                    j += 1;
+                }
+                Ordering::Greater => {
+                    // In new but not in old → addition
+                    added.push(new_base[j]);
+                    j += 1;
+                }
+            }
+        }
+        // Remaining old entries are removals
+        if i < self.base.len() {
+            has_removals = true;
+        }
+        // Remaining new entries are additions
+        while j < new_base.len() {
+            added.push(new_base[j]);
+            j += 1;
+        }
+
+        if !has_removals && added.is_empty() {
+            return false; // No change
+        }
+
+        if has_removals {
+            // Removals detected: replace base and reset everything
+            self.base = new_base;
+            self.clear(); // Resets input=base, recreates all Variables
+            true
+        } else {
+            // Additions only: route through incremental path
+            self.base = new_base;
+            if self.is_materialized {
+                // Dedup additions against materialized closure
+                get_unique(&self.input, &mut added);
+                self.pending_delta.extend(added);
+            } else {
+                self.input = self.base.clone();
+            }
+            false
+        }
+    }
+
     fn add_error(&mut self, rule: String, message: String) {
         if !self.options.collect_diagnostics {
             return;

--- a/lib/src/tests.rs
+++ b/lib/src/tests.rs
@@ -1592,3 +1592,145 @@ fn test_incremental_does_not_support_retraction() {
         "New reasoner without x: the inference should be gone"
     );
 }
+
+// ==================== set_base_triples() tests ====================
+
+/// Helper to build oxrdf triples from string URIs for use with set_base_triples()
+fn make_test_triples(trips: Vec<(&str, &str, &str)>) -> Vec<oxrdf::Triple> {
+    use crate::common::make_triple;
+    trips
+        .into_iter()
+        .map(|(s, p, o)| {
+            make_triple(
+                oxrdf::Term::NamedNode(oxrdf::NamedNode::new(s).unwrap()),
+                oxrdf::Term::NamedNode(oxrdf::NamedNode::new(p).unwrap()),
+                oxrdf::Term::NamedNode(oxrdf::NamedNode::new(o).unwrap()),
+            )
+            .unwrap()
+        })
+        .collect()
+}
+
+#[test]
+fn test_set_base_triples_additions_only() {
+    let mut r = Reasoner::new();
+    r.load_triples_str(vec![("urn:A", RDFS_SUBCLASSOF, "urn:B")]);
+    r.reason();
+
+    // set_base_triples with a superset (adds x rdf:type A)
+    let needs_full = r.set_base_triples(make_test_triples(vec![
+        ("urn:A", RDFS_SUBCLASSOF, "urn:B"),
+        ("urn:x", RDF_TYPE, "urn:A"),
+    ]));
+    assert!(!needs_full, "Additions only should not require full re-materialization");
+
+    r.reason();
+    let res = r.get_triples_string();
+    assert!(
+        res.contains(&("<urn:x>".to_string(), wrap!(RDF_TYPE), "<urn:B>".to_string())),
+        "Incremental: x should be inferred as type B"
+    );
+}
+
+#[test]
+fn test_set_base_triples_with_removals() {
+    let mut r = Reasoner::new();
+    r.load_triples_str(vec![
+        ("urn:A", RDFS_SUBCLASSOF, "urn:B"),
+        ("urn:x", RDF_TYPE, "urn:A"),
+    ]);
+    r.reason();
+
+    let res = r.get_triples_string();
+    assert!(res.contains(&("<urn:x>".to_string(), wrap!(RDF_TYPE), "<urn:B>".to_string())));
+
+    // Remove (x, rdf:type, A) by setting base to just the subClassOf triple
+    let needs_full = r.set_base_triples(make_test_triples(vec![
+        ("urn:A", RDFS_SUBCLASSOF, "urn:B"),
+    ]));
+    assert!(needs_full, "Removals should require full re-materialization");
+
+    r.reason();
+    let res = r.get_triples_string();
+    assert!(
+        !res.contains(&("<urn:x>".to_string(), wrap!(RDF_TYPE), "<urn:B>".to_string())),
+        "After removing x from base, inference should be gone"
+    );
+}
+
+#[test]
+fn test_set_base_triples_mixed() {
+    let mut r = Reasoner::new();
+    r.load_triples_str(vec![
+        ("urn:A", RDFS_SUBCLASSOF, "urn:B"),
+        ("urn:x", RDF_TYPE, "urn:A"),
+    ]);
+    r.reason();
+
+    // Replace: remove x, add y
+    let needs_full = r.set_base_triples(make_test_triples(vec![
+        ("urn:A", RDFS_SUBCLASSOF, "urn:B"),
+        ("urn:y", RDF_TYPE, "urn:A"),
+    ]));
+    assert!(needs_full, "Mixed add+remove should require full re-materialization");
+
+    r.reason();
+    let res = r.get_triples_string();
+    assert!(
+        !res.contains(&("<urn:x>".to_string(), wrap!(RDF_TYPE), "<urn:B>".to_string())),
+        "x inference should be gone"
+    );
+    assert!(
+        res.contains(&("<urn:y>".to_string(), wrap!(RDF_TYPE), "<urn:B>".to_string())),
+        "y inference should be present"
+    );
+}
+
+#[test]
+fn test_set_base_triples_no_change() {
+    let mut r = Reasoner::new();
+    r.load_triples_str(vec![
+        ("urn:A", RDFS_SUBCLASSOF, "urn:B"),
+        ("urn:x", RDF_TYPE, "urn:A"),
+    ]);
+    r.reason();
+    let res1 = r.get_triples_string();
+
+    // Set identical base
+    let needs_full = r.set_base_triples(make_test_triples(vec![
+        ("urn:A", RDFS_SUBCLASSOF, "urn:B"),
+        ("urn:x", RDF_TYPE, "urn:A"),
+    ]));
+    assert!(!needs_full, "No change should be a no-op");
+
+    r.reason(); // Should be no-op since no delta
+    let res2 = r.get_triples_string();
+    assert_eq!(res1, res2, "No change in base should produce identical output");
+}
+
+#[test]
+fn test_set_base_triples_equivalence() {
+    // Additions-only via set_base_triples should match fresh full materialization
+    let mut r = Reasoner::new();
+    r.load_triples_str(vec![("urn:A", RDFS_SUBCLASSOF, "urn:B")]);
+    r.reason();
+
+    r.set_base_triples(make_test_triples(vec![
+        ("urn:A", RDFS_SUBCLASSOF, "urn:B"),
+        ("urn:x", RDF_TYPE, "urn:A"),
+    ]));
+    r.reason();
+    let mut incr = r.get_triples_string();
+    incr.sort();
+
+    let mut full = Reasoner::new();
+    full.load_triples_str(vec![
+        ("urn:A", RDFS_SUBCLASSOF, "urn:B"),
+        ("urn:x", RDF_TYPE, "urn:A"),
+    ]);
+    full.reason();
+    let mut full_res = full.get_triples_string();
+    full_res.sort();
+
+    assert_eq!(incr, full_res, "Incremental set_base_triples should match full materialization");
+}

--- a/python/README.md
+++ b/python/README.md
@@ -36,6 +36,33 @@ for s, p, o in triples:
 print(len(g_out))
 ```
 
+### Incremental Reasoning with Retraction
+
+Use `update_graph()` to replace the reasoner's base triples when your graph changes. The reasoner automatically computes a diff and selects incremental materialization (additions only) or full re-materialization (if removals detected):
+
+```python
+import rdflib
+import reasonable
+from rdflib import URIRef, RDF
+
+ontology = rdflib.Graph()
+ontology.parse("my_ontology.ttl")
+
+data = rdflib.Graph()
+data.add((URIRef("urn:sensor1"), RDF.type, URIRef("urn:TemperatureSensor")))
+
+r = reasonable.PyReasoner()
+r.from_graph(ontology + data)
+triples = r.reason()  # full materialization
+
+# Later, data changes...
+data.remove((URIRef("urn:sensor1"), RDF.type, URIRef("urn:TemperatureSensor")))
+data.add((URIRef("urn:sensor2"), RDF.type, URIRef("urn:HumiditySensor")))
+
+r.update_graph(ontology + data)  # replaces base, auto-detects diff
+triples = r.reason()             # full re-mat (removals detected)
+```
+
 ## Install
 - Runtime dependency: `rdflib`
 - If you have a prebuilt wheel: `pip install dist/reasonable-*.whl`
@@ -66,14 +93,22 @@ maturin develop -b pyo3 --release
 python -c "import reasonable; print(reasonable.__version__)"
 ```
 
-## API Reference (minimal)
+## API Reference
 - `reasonable.PyReasoner()`
   - `load_file(path: str) -> None`
-    - Load triples from a Turtle or N3 file. Raises `OSError` on missing/invalid paths.
+    - Load triples from a Turtle or N3 file. **Appends** to existing base triples. Raises `OSError` on missing/invalid paths.
   - `from_graph(graph_or_iterable) -> None`
-    - Accepts an rdflib `Graph` or any iterable of 3-tuples convertible to rdflib-like nodes.
+    - **Appends** triples from an rdflib `Graph` (or any iterable of 3-tuples) to the base. Use `update_graph()` instead if you need retraction support.
+  - `update_graph(graph_or_iterable) -> bool`
+    - **Replaces** the base triples with the contents of the given graph. Computes a diff against the current base: if only additions are found, the next `reason()` uses incremental materialization; if any removals are detected, it triggers a full re-materialization. Returns `True` if removals were detected, `False` otherwise.
   - `reason() -> list[tuple[Node, Node, Node]]`
-    - Runs OWL 2 RL materialization and returns all known triples as rdflib nodes.
+    - Runs OWL 2 RL materialization and returns all known triples (base + inferred) as rdflib nodes. After the first call, subsequent calls are incremental (only processing newly added triples) unless removals were detected via `update_graph()`.
+  - `reason_full() -> list[tuple[Node, Node, Node]]`
+    - Forces a full re-materialization from base triples, ignoring any incremental state. Equivalent to `clear()` followed by `reason()`.
+  - `clear() -> None`
+    - Resets all inferred state while keeping base triples. The next `reason()` call will perform a full re-materialization.
+  - `get_base_triples() -> list[tuple[Node, Node, Node]]`
+    - Returns the current base (non-inferred) triples as rdflib nodes. Useful for debugging.
 
 ## Building Wheels
 Build release wheels into `dist/`:

--- a/python/src/pyreason.rs
+++ b/python/src/pyreason.rs
@@ -110,6 +110,50 @@ fn term_to_python<'a>(
     Ok(res)
 }
 
+/// Converts the output of reason() or get_triples() to Python rdflib terms.
+fn triples_to_python(
+    py: Python,
+    triples: Vec<Triple>,
+) -> PyResult<Vec<(Py<PyAny>, Py<PyAny>, Py<PyAny>)>> {
+    let rdflib = py.import("rdflib")?;
+    let mut res = Vec::new();
+    for t in triples {
+        let s = term_to_python(py, &rdflib, Term::from(t.subject.clone()))?;
+        let p = term_to_python(py, &rdflib, Term::from(t.predicate.clone()))?;
+        let o = term_to_python(py, &rdflib, Term::from(t.object.clone()))?;
+        res.push((s.into(), p.into(), o.into()));
+    }
+    Ok(res)
+}
+
+/// Extracts triples from an rdflib Graph (or any iterable of 3-tuples) into oxrdf Triples.
+fn extract_triples_from_graph(py: Python, graph: &PyObject) -> PyResult<Vec<Triple>> {
+    let converters = PyModule::from_code(
+        py,
+        c_str!(
+            "def get_triples(graph):
+    return list(graph)
+"
+        ),
+        c_str!("converters.pg"),
+        c_str!("converters"),
+    )?;
+    let binding = converters.getattr("get_triples")?.call1((graph,))?;
+    let l: &Bound<'_, PyList> = binding.downcast()?;
+    let mut triples: Vec<Triple> = Vec::new();
+    for t in l.iter() {
+        let t: &Bound<'_, PyTuple> = t.downcast()?;
+        let s = MyTerm::from(t.get_item(0)).0;
+        let p = MyTerm::from(t.get_item(1)).0;
+        let o = MyTerm::from(t.get_item(2)).0;
+        match make_triple(s, p, o) {
+            Ok(triple) => triples.push(triple),
+            Err(e) => return Err(PyReasoningError(e).into()),
+        };
+    }
+    Ok(triples)
+}
+
 #[pyclass(unsendable)]
 pub struct PyReasoner {
     reasoner: reasoner::Reasoner,
@@ -138,48 +182,60 @@ impl PyReasoner {
     /// definitions in order to use them. Returns a list of triples
     pub fn reason(&mut self) -> PyResult<Vec<(Py<PyAny>, Py<PyAny>, Py<PyAny>)>> {
         Python::with_gil(|py| {
-            let rdflib = py.import("rdflib")?;
             self.reasoner.reason();
-            let mut res = Vec::new();
-            for t in self.reasoner.get_triples() {
-                let s = term_to_python(py, &rdflib, Term::from(t.subject.clone()))?;
-                let p = term_to_python(py, &rdflib, Term::from(t.predicate.clone()))?;
-                let o = term_to_python(py, &rdflib, Term::from(t.object.clone()))?;
-                res.push((s.into(), p.into(), o.into()));
-            }
-            Ok(res)
+            triples_to_python(py, self.reasoner.get_triples())
         })
     }
 
     /// Loads in triples from an RDFlib Graph or any other object that can be converted into a list
-    /// of triples (length-3 tuples of URI-formatted strings)
+    /// of triples (length-3 tuples of URI-formatted strings).
+    ///
+    /// Note: this *appends* to the existing base triples. To *replace* the base
+    /// (supporting retraction), use `update_graph()` instead.
     pub fn from_graph(&mut self, graph: PyObject) -> PyResult<()> {
         Python::with_gil(|py| {
-            let converters = PyModule::from_code(
-                py,
-                c_str!(
-                    "def get_triples(graph):
-    return list(graph)
-"
-                ),
-                c_str!("converters.pg"),
-                c_str!("converters"),
-            )?;
-            let binding = converters.getattr("get_triples")?.call1((graph,))?;
-            let l: &Bound<'_, PyList> = binding.downcast()?;
-            let mut triples: Vec<Triple> = Vec::new();
-            for t in l.iter() {
-                let t: &Bound<'_, PyTuple> = t.downcast()?;
-                let s = MyTerm::from(t.get_item(0)).0;
-                let p = MyTerm::from(t.get_item(1)).0;
-                let o = MyTerm::from(t.get_item(2)).0;
-                match make_triple(s, p, o) {
-                    Ok(triple) => triples.push(triple),
-                    Err(e) => return Err(PyReasoningError(e).into()),
-                };
-            }
+            let triples = extract_triples_from_graph(py, &graph)?;
             self.reasoner.load_triples(triples);
             Ok(())
+        })
+    }
+
+    /// Replaces the reasoner's base triples with the contents of the given graph.
+    ///
+    /// Computes a diff against the current base:
+    /// - If only additions are detected, the next `reason()` call uses incremental materialization.
+    /// - If any removals are detected, the next `reason()` call performs a full re-materialization.
+    ///
+    /// Returns `True` if removals were detected (full re-materialization needed),
+    /// `False` if only additions (or no change).
+    pub fn update_graph(&mut self, graph: PyObject) -> PyResult<bool> {
+        Python::with_gil(|py| {
+            let triples = extract_triples_from_graph(py, &graph)?;
+            let needs_full = self.reasoner.set_base_triples(triples);
+            Ok(needs_full)
+        })
+    }
+
+    /// Clears all inferred state, resetting to base triples.
+    /// The next `reason()` call will perform a full re-materialization.
+    pub fn clear(&mut self) {
+        self.reasoner.clear();
+    }
+
+    /// Forces a full re-materialization from base triples.
+    /// Equivalent to `clear()` followed by `reason()`.
+    /// Returns a list of all triples (base + inferred).
+    pub fn reason_full(&mut self) -> PyResult<Vec<(Py<PyAny>, Py<PyAny>, Py<PyAny>)>> {
+        Python::with_gil(|py| {
+            self.reasoner.reason_full();
+            triples_to_python(py, self.reasoner.get_triples())
+        })
+    }
+
+    /// Returns the current base (non-inferred) triples as rdflib terms.
+    pub fn get_base_triples(&self) -> PyResult<Vec<(Py<PyAny>, Py<PyAny>, Py<PyAny>)>> {
+        Python::with_gil(|py| {
+            triples_to_python(py, self.reasoner.get_input())
         })
     }
 }

--- a/python/tests/test_pyreasoner.py
+++ b/python/tests/test_pyreasoner.py
@@ -420,3 +420,138 @@ def test_error_asymmetric():
         ("urn:x", "urn:p", "urn:y"),
         ("urn:y", "urn:p", "urn:x"),
     ])
+
+
+# ==================== Incremental / retraction tests ====================
+
+RDFS_SUBCLASSOF = "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+
+
+def _triple_set(triples):
+    """Convert list of (s, p, o) tuples to a set for comparison."""
+    return set((str(s), str(p), str(o)) for s, p, o in triples)
+
+
+def test_update_graph_additions_only():
+    """update_graph with a superset should be incremental (returns False)."""
+    import reasonable
+    from rdflib import Graph, URIRef
+
+    g = Graph()
+    g.add((URIRef("urn:A"), URIRef(RDFS_SUBCLASSOF), URIRef("urn:B")))
+
+    r = reasonable.PyReasoner()
+    r.from_graph(g)
+    r.reason()
+
+    # Add a triple
+    g.add((URIRef("urn:x"), URIRef(RDF_TYPE), URIRef("urn:A")))
+    needs_full = r.update_graph(g)
+    assert needs_full is False, "Additions only should not need full re-materialization"
+
+    out = r.reason()
+    out_set = _triple_set(out)
+    assert ("urn:x", RDF_TYPE, "urn:B") in out_set, "Should infer x rdf:type B"
+
+
+def test_update_graph_with_removals():
+    """update_graph with removals should trigger full re-materialization."""
+    import reasonable
+    from rdflib import Graph, URIRef
+
+    g = Graph()
+    g.add((URIRef("urn:A"), URIRef(RDFS_SUBCLASSOF), URIRef("urn:B")))
+    g.add((URIRef("urn:x"), URIRef(RDF_TYPE), URIRef("urn:A")))
+
+    r = reasonable.PyReasoner()
+    r.from_graph(g)
+    out = r.reason()
+    out_set = _triple_set(out)
+    assert ("urn:x", RDF_TYPE, "urn:B") in out_set
+
+    # Remove the instance triple
+    g.remove((URIRef("urn:x"), URIRef(RDF_TYPE), URIRef("urn:A")))
+    needs_full = r.update_graph(g)
+    assert needs_full is True, "Removal should trigger full re-materialization"
+
+    out = r.reason()
+    out_set = _triple_set(out)
+    assert ("urn:x", RDF_TYPE, "urn:B") not in out_set, \
+        "After retraction, x rdf:type B should be gone"
+
+
+def test_update_graph_mixed():
+    """update_graph with both additions and removals."""
+    import reasonable
+    from rdflib import Graph, URIRef
+
+    g = Graph()
+    g.add((URIRef("urn:A"), URIRef(RDFS_SUBCLASSOF), URIRef("urn:B")))
+    g.add((URIRef("urn:x"), URIRef(RDF_TYPE), URIRef("urn:A")))
+
+    r = reasonable.PyReasoner()
+    r.from_graph(g)
+    r.reason()
+
+    # Replace x with y
+    g.remove((URIRef("urn:x"), URIRef(RDF_TYPE), URIRef("urn:A")))
+    g.add((URIRef("urn:y"), URIRef(RDF_TYPE), URIRef("urn:A")))
+    needs_full = r.update_graph(g)
+    assert needs_full is True
+
+    out = r.reason()
+    out_set = _triple_set(out)
+    assert ("urn:x", RDF_TYPE, "urn:B") not in out_set, "x inference should be gone"
+    assert ("urn:y", RDF_TYPE, "urn:B") in out_set, "y inference should be present"
+
+
+def test_clear_exposed():
+    """clear() should be callable from Python."""
+    import reasonable
+
+    r = reasonable.PyReasoner()
+    r.load_file("../example_models/ontologies/rdfs.ttl")
+    r.reason()
+    r.clear()
+    out = r.reason()
+    # Should still produce results (clear resets to base, not empty)
+    assert len(out) > 0
+
+
+def test_reason_full_exposed():
+    """reason_full() should force full re-materialization."""
+    import reasonable
+    from rdflib import Graph, URIRef
+
+    g = Graph()
+    g.add((URIRef("urn:A"), URIRef(RDFS_SUBCLASSOF), URIRef("urn:B")))
+    g.add((URIRef("urn:x"), URIRef(RDF_TYPE), URIRef("urn:A")))
+
+    r = reasonable.PyReasoner()
+    r.from_graph(g)
+    out1 = r.reason()
+    out2 = r.reason_full()
+    assert _triple_set(out1) == _triple_set(out2), \
+        "reason_full() should match reason() when nothing changed"
+
+
+def test_get_base_triples():
+    """get_base_triples() should return the non-inferred triples."""
+    import reasonable
+    from rdflib import Graph, URIRef
+
+    g = Graph()
+    g.add((URIRef("urn:A"), URIRef(RDFS_SUBCLASSOF), URIRef("urn:B")))
+    g.add((URIRef("urn:x"), URIRef(RDF_TYPE), URIRef("urn:A")))
+
+    r = reasonable.PyReasoner()
+    r.from_graph(g)
+    r.reason()
+
+    base = r.get_base_triples()
+    base_set = _triple_set(base)
+    # User triples should be in base
+    assert ("urn:A", RDFS_SUBCLASSOF, "urn:B") in base_set
+    assert ("urn:x", RDF_TYPE, "urn:A") in base_set
+    # Inferred triples should NOT be in base
+    assert ("urn:x", RDF_TYPE, "urn:B") not in base_set


### PR DESCRIPTION
This PR is a follow-up of #42 (and based upon it), that correctly expose RDF graph update to Python (and, as a side effect, makes incremental materialization available in Python as well).

## Summary

This PR adds support for triple retraction in the Python bindings, enabling proper incremental reasoning workflows from Python. The key addition is `update_graph(graph)` — a method that **replaces** the reasoner's base triples (rather than appending), automatically computes a diff, and selects incremental materialization or full re-materialization as appropriate.

## Motivation

The Python `PyReasoner` previously had no way to retract triples. `from_graph()` always appends to the reasoner's permanent base: if a user removes triples from their rdflib `Graph` and calls `from_graph()` again, the removed triples silently persist and the reasoner produces stale inferences. This effectively prevents incremental reasoning from Python: either users recreate a `PyReasoner()` from scratch each time (losing incremental benefits), or they risk reasoning over an invalid set of triples.

Consider a typical robotics/IoT workflow:
```python
r = reasonable.PyReasoner()
r.from_graph(ontology + sensor_data)
r.reason()

# Sensor data changes over time...
sensor_data.remove(old_reading)
sensor_data.add(new_reading)

# BUG: from_graph() appends — old_reading is still in the reasoner!
r.from_graph(sensor_data)
r.reason()  # produces stale inferences from old_reading
```

## Solution

A new `update_graph(graph)` method that **replaces** the base triples with the graph contents. Under the hood, it computes a sorted linear-merge diff against the current base:

- **Additions only** → routes new triples to `pending_delta` for incremental reasoning (fast path)
- **Any removals** → calls `clear()` and resets state, so the next `reason()` performs a full re-materialization (correct path)

The method returns `True` if removals were detected (informational, the user still just calls `reason()`).

The correct workflow becomes:
```python
r = reasonable.PyReasoner()
r.from_graph(ontology + sensor_data)
r.reason()

# Sensor data changes...
sensor_data.remove(old_reading)
sensor_data.add(new_reading)

r.update_graph(ontology + sensor_data)  # replaces base, detects diff
r.reason()  # incremental if only additions, full re-mat if removals
```

## Commits

(this PR only introduce 2 new commits, the other commits come from #42)

### `cd4072f` Add `set_base_triples()` for base replacement with automatic diff

Adds a new public method to the Rust `Reasoner`:

```rust
pub fn set_base_triples(&mut self, triples: Vec<Triple>) -> bool
```

This replaces the base triples entirely and computes a diff against the old base via a linear merge of two sorted vectors (O(n+m)):
- If only additions are found, they are routed to `pending_delta` for incremental materialization on the next `reason()` call.
- If any removals are found, the reasoner calls `clear()` internally, so the next `reason()` performs a full re-materialization from the new base.
- Seed triples (`owl:Thing`/`owl:Nothing rdf:type owl:Class`) are automatically preserved regardless of user input.
- Returns `true` if removals were detected, `false` otherwise.

Includes 5 Rust tests: additions-only (incremental path), removals (full re-mat path), mixed add+remove, no-change (no-op), and equivalence with a fresh full materialization.

### `5e7ca23` Add `update_graph()`, `clear()`, `reason_full()`, `get_base_triples()` to Python bindings

Exposes the new Rust capability to Python and adds supporting methods:

- **`update_graph(graph)`** — Replaces the base triples with the contents of the given rdflib `Graph`. Returns `True` if removals were detected (full re-materialization needed), `False` if only additions (incremental). This is the main user-facing method for retraction.

- **`clear()`** — Resets all inferred state, keeping base triples. The next `reason()` performs a full re-materialization. Exposed as a lower-level building block.

- **`reason_full()`** — Forces a full re-materialization from base triples. Equivalent to `clear()` + `reason()`.

- **`get_base_triples()`** — Returns the current base (non-inferred) triples as rdflib terms. Useful for debugging and verifying what the reasoner considers its input.

Also refactors the existing `from_graph()` and `reason()` code to use shared helpers (`extract_triples_from_graph()`, `triples_to_python()`), reducing duplication.

Includes 7 Python integration tests covering: additions-only incremental, removal retraction, mixed add/remove, `clear()`, `reason_full()`, and `get_base_triples()`.

## API Summary

| Method | Behavior | Existing/New |
|---|---|---|
| `from_graph(g)` | **Appends** triples from graph to base | Existing (unchanged) |
| `update_graph(g)` | **Replaces** base with graph contents; auto-diffs | **New** |
| `clear()` | Resets inferred state, keeps base | **New** (was Rust-only) |
| `reason_full()` | Forces full re-materialization | **New** |
| `get_base_triples()` | Returns non-inferred base triples | **New** |
| `reason()` | Incremental or full materialization | Existing (unchanged) |
| `load_file(path)` | Appends triples from file | Existing (unchanged) |
