### PR TITLE
Refresh Makefile Python targets and document build/test workflow in README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,4 @@
-.PHONY: test build deb deb-python
-
-#PY36_VERSION=3.6.10
-PY37_VERSION=3.7.10
-PY38_VERSION=3.8.8
-PY39_VERSION=3.9.7
-#PY3A_VERSION=3.10.0
-#PY36_PATH=$(shell pyenv prefix $(PY36_VERSION))
-PY37_PATH=$(shell pyenv prefix $(PY37_VERSION))
-PY38_PATH=$(shell pyenv prefix $(PY38_VERSION))
-PY39_PATH=$(shell pyenv prefix $(PY39_VERSION))
-#PY3A_PATH=$(shell pyenv prefix $(PY3A_VERSION))
-PY36_BIN=$(PY36_PATH)/bin/python
-PY37_BIN=$(PY37_PATH)/bin/python
-PY38_BIN=$(PY38_PATH)/bin/python
-PY39_BIN=$(PY39_PATH)/bin/python
-PY3A_BIN=$(PY3A_PATH)/bin/python
+.PHONY: build build-tiny test bench dev-python-library build-python-library test-python bench-python deb deb-python
 
 build:
 	cargo build --release
@@ -25,41 +9,24 @@ build-tiny:
 test:
 	cargo test
 
-# for macos, do
-# cp target/release/libreasonable.dylib reasonable/reasonable.so
-# this test is missing brick_inference_test.n3 so it doens't work
-test-python:
-	cargo build --lib --release --features "python-library"
-	cp ./target/release/libreasonable.so reasonable/reasonable.so
-	python test.py
-
-install-python-versions:
-	# requires pyenv
-	#pyenv install -s $(PY36_VERSION)
-	pyenv install -s $(PY37_VERSION)
-	pyenv install -s $(PY38_VERSION)
-	pyenv install -s $(PY39_VERSION)
-	#pyenv install -s $(PY3A_VERSION)
-
-python-build-remove:
-	# cargo build --lib --release -v --features python-library -Zunstable-options -- --pretty=expanded
-	cargo rustc --lib --release  --features python-library --profile=check -- -Zunstable-options --pretty=expanded
-
-dev-python-library:
-	cd python && poetry run maturin develop -b pyo3 --release
-	poetry run python lang.py
-
-build-python-library:
-	cd python && poetry run maturin build  -b pyo3
-
 bench: build
 	./scripts/bench_examples.sh
 
-.PHONY: deb
+dev-python-library:
+	cd python && uv run maturin develop -b pyo3 --release
+
+build-python-library:
+	cd python && uv run maturin build -b pyo3 --release --out dist
+
+test-python: dev-python-library
+	cd python && uv run pytest -q
+
+bench-python:
+	cd benches/python && uv run bench.py
+
 deb:
 	# Requires: cargo install cargo-deb
 	./scripts/build_deb.sh
 
-.PHONY: deb-python
 deb-python:
 	./scripts/build_python_deb.sh

--- a/README.md
+++ b/README.md
@@ -129,6 +129,31 @@ fn main() {
 ```
 
 
+## Building from Source
+
+Most common workflows are wrapped as `make` targets. You'll need a Rust toolchain (install via [rustup](https://rustup.rs/)) for everything, and additionally [uv](https://docs.astral.sh/uv/) plus Python 3.9+ for the Python bindings.
+
+### Rust library and CLI
+
+```bash
+make build        # release build; produces ./target/release/reasonable
+make test         # run the Rust test suite
+make bench        # end-to-end benchmark vs. OWLRL on example_models/
+```
+
+For the criterion micro-benchmarks in `benches/my_benchmark.rs`, run `cargo bench` directly.
+
+### Python bindings
+
+The Python bindings live in `python/` and are built with [maturin](https://www.maturin.rs/) via `uv`.
+
+```bash
+make dev-python-library   # build the extension and install it into python/.venv
+make test-python          # build + run the pytest suite in python/tests/
+make bench-python         # run benches/python/bench.py (vs. OWLRL, Allegro, owlready2)
+make build-python-library # build a distributable wheel into python/dist/
+```
+
 ## OWL 2 Rules
 
 Using rule definitions from [here](https://www.w3.org/TR/owl2-profiles/#Reasoning_in_OWL_2_RL_and_RDF_Graphs_using_Rules).


### PR DESCRIPTION
Switches Python make targets from the stale poetry setup to uv, fixes the broken test-python target (now builds the extension and runs pytest), adds a bench-python target for benches/python/bench.py, and drops dead pyenv boilerplate. Adds a "Building from Source" section to the README that points at the make targets for both Rust and Python workflows.