### PR TITLE
remove unused dependencies

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -14,14 +14,8 @@ rio_turtle.workspace = true
 rio_api.workspace = true
 oxrdf.workspace = true
 datafrog.workspace = true
-roaring.workspace = true
-itertools.workspace = true
 disjoint-sets.workspace = true
 log.workspace = true
-env_logger.workspace = true
-tinytemplate.workspace = true
-anyhow.workspace = true
-clap.workspace = true
 thiserror = "1.0"
 
 # optional deps for legacy query module (rdf stack)
@@ -29,10 +23,6 @@ regex = { version = "1", optional = true }
 serde = { version = "1", optional = true, features = ["derive"] }
 serde_sexpr = { version = "0.1", optional = true }
 farmhash = { version = "1", optional = true }
-
-# keep serde_json if used elsewhere; not required by legacy query
-serde_json.workspace = true
-serde_derive.workspace = true
 
 [features]
 # Default build excludes the legacy query module and its rdf stack


### PR DESCRIPTION
I was tracing some downstream `cargo audit` warnings and noticed these dependencies are no longer used in `lib/Cargo.toml` after the refactor as they mostly moved under the dedicated CLI. Any reason to keep them around?

Additionally, while currently not included in this PR:
```bash
$ cargo machete
Analyzing dependencies of crates in this directory...
cargo-machete found the following unused dependencies in this directory:
reasonable -- ./lib/Cargo.toml:
        farmhash
        regex
        serde
        serde_sexpr
```
These are behind a non-default feature flag so not as big an impact - but I noticed they (and the feature flag itself) no longer has any references under `lib/`. Any reason the `legacy-query` feature still exists? Or the specific optional dependencies under it? If it's going through a deprecation cycle, maybe keep the feature flag in place but modify `lib/Cargo.toml` to just be 
```
legacy-query = []
```

Original audit warnings:
```bash
$ cargo audit
...
Crate:     atty
Version:   0.2.14
Warning:   unmaintained
Title:     `atty` is unmaintained
Date:      2024-09-25
ID:        RUSTSEC-2024-0375
URL:       https://rustsec.org/advisories/RUSTSEC-2024-0375
Dependency tree:
atty 0.2.14
└── env_logger 0.7.1
    └── reasonable-cli 0.4.1

Crate:     atty
Version:   0.2.14
Warning:   unsound
Title:     Potential unaligned read
Date:      2021-07-04
ID:        RUSTSEC-2021-0145
URL:       https://rustsec.org/advisories/RUSTSEC-2021-0145

warning: 2 allowed warnings found
```