### PR TITLE
Add support for rdfs container and datatype

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Common diagnostic codes:
 - `OWLRL.PRP_ASYP`: Asymmetric property used both directions
 - `OWLRL.PRP_IRP`: Irreflexive property used with same subject/object
 - `OWLRL.CLS_NOTHING`: Individual typed as owl:Nothing
+- `RDFS.DATATYPE`: Typed literal whose lexical form is ill-formed for its declared datatype
+- `RDFS.DATATYPE_RANGE`: Object literal's datatype is not in the value space of the predicate's `rdfs:range`
 
 Example strict run:
 
@@ -183,8 +185,11 @@ Using rule definitions from [here](https://www.w3.org/TR/owl2-profiles/#Reasonin
 |Completed| Rule name | Notes |
 |---------|----------|-------|
 | **yes**| `rdfs11` | `rdfs:subClassOf` transitivity |
+| **yes**| `rdfs12` | container membership: each `rdf:_n` (n>0) axiomatised as `rdf:type rdf:Property`, `rdf:type rdfs:ContainerMembershipProperty`, `rdfs:subPropertyOf rdfs:member` (the last yields `x rdfs:member y` via `prp-spo1`) |
+| **yes**| `rdfs-datatype` | ill-formed typed literal diagnostic; recognises `xsd:string`, `xsd:integer`, `xsd:int`, `rdf:langString`, `rdf:XMLLiteral` |
+| **yes**| `rdfs-datatype-range` | object literal's datatype must lie in the value space of the predicate's `rdfs:range` datatype; otherwise a diagnostic is emitted |
 
-**Note**: haven't implemented rules that produce exceptions; waiting to determine the best way of handling these errors.
+**Note**: remaining unimplemented RDFS rules are mostly those that throw exceptions; waiting to determine the best way of handling these errors.
 
 ### Equality Semantics
 
@@ -268,7 +273,7 @@ Using rule definitions from [here](https://www.w3.org/TR/owl2-profiles/#Reasonin
 
 ### Other
 
-- no datatype semantics for now
+- partial datatype semantics — see the `rdfs-datatype` and `rdfs-datatype-range` rows in the RDFS Semantics table above
 
 ## Development Notes
 

--- a/lib/src/reasoner.rs
+++ b/lib/src/reasoner.rs
@@ -899,6 +899,92 @@ impl Reasoner {
         self.errors.push(error);
     }
 
+    fn inject_rdfs_container_membership_axioms(&mut self) {
+        let rdf_type = self.index.put(rdf!("type"));
+        let rdf_property = self.index.put(rdf!("Property"));
+        let rdfs_container_membership_property =
+            self.index.put(rdfs!("ContainerMembershipProperty"));
+        let rdfs_sub_property_of = self.index.put(rdfs!("subPropertyOf"));
+        let rdfs_member = self.index.put(rdfs!("member"));
+
+        let mut seen_predicates = HashSet::new();
+        let mut axioms = Vec::new();
+        for (_, (predicate, _)) in &self.input {
+            if *predicate == 0 || !seen_predicates.insert(*predicate) {
+                continue;
+            }
+            let Some(Term::NamedNode(predicate_node)) = self.index.get(*predicate) else {
+                continue;
+            };
+            if !is_rdf_container_membership_property_iri(predicate_node.as_str()) {
+                continue;
+            }
+            axioms.push((*predicate, (rdf_type, rdf_property)));
+            axioms.push((*predicate, (rdf_type, rdfs_container_membership_property)));
+            axioms.push((*predicate, (rdfs_sub_property_of, rdfs_member)));
+        }
+        if axioms.is_empty() {
+            return;
+        }
+        axioms.sort_unstable();
+        self.input.sort_unstable();
+        get_unique(&self.input, &mut axioms);
+        self.add_base_triples(axioms);
+    }
+
+    fn detect_rdfs_datatype_inconsistencies(&mut self, triples: &[KeyedTriple]) {
+        let rdfs_range = self.index.put(rdfs!("range"));
+        let mut ranges: HashMap<URI, Vec<URI>> = HashMap::new();
+        for (subject, (predicate, object)) in triples {
+            if *predicate == rdfs_range {
+                ranges.entry(*subject).or_default().push(*object);
+            }
+        }
+
+        let mut violations: Vec<(String, String)> = Vec::new();
+
+        for (subject, (predicate, object)) in triples {
+            if let Some(Term::Literal(literal)) = self.index.get(*object) {
+                let datatype_iri = literal.datatype().as_str();
+                if let Some(false) = literal_well_formed_for_datatype(literal, datatype_iri) {
+                    let message = format!(
+                        "ill-formed literal {} used in triple {} {} {}",
+                        literal,
+                        self.to_u(*subject),
+                        self.to_u(*predicate),
+                        self.to_u(*object)
+                    );
+                    violations.push(("rdfs-datatype".to_string(), message));
+                }
+            }
+
+            let Some(range_targets) = ranges.get(predicate) else {
+                continue;
+            };
+            let Some(object_term) = self.index.get(*object) else {
+                continue;
+            };
+            for range_target in range_targets {
+                let Some(Term::NamedNode(range_node)) = self.index.get(*range_target) else {
+                    continue;
+                };
+                if let Some(false) = term_in_datatype_space(object_term, range_node.as_str()) {
+                    let message = format!(
+                        "range clash: object {} is not in datatype {} for predicate {}",
+                        self.to_u(*object),
+                        range_node,
+                        self.to_u(*predicate)
+                    );
+                    violations.push(("rdfs-datatype-range".to_string(), message));
+                }
+            }
+        }
+
+        for (rule, message) in violations {
+            self.add_error(rule, message);
+        }
+    }
+
     /// Returns a read-only view of errors detected during reasoning (e.g., disjointness violations).
     pub fn errors(&self) -> &[ReasoningError] {
         &self.errors
@@ -1021,6 +1107,16 @@ impl Reasoner {
         let rdftype_node = self.rdftype_node;
         let owlthing_node = self.owlthing_node;
         let owlsameas_node = self.owlsameas_node;
+
+        // RDFS container membership properties (rdf:_n) carry axiomatic
+        // consequences:
+        //   rdf:_n rdf:type rdf:Property ;
+        //          rdf:type rdfs:ContainerMembershipProperty ;
+        //          rdfs:subPropertyOf rdfs:member .
+        // Inject those axioms before fixpoint so they participate in the
+        // closure. Idempotent: the injector dedups against `self.input`,
+        // so running it on every `reason()` call is safe.
+        self.inject_rdfs_container_membership_axioms();
 
         if self.is_materialized {
             // Incremental mode: only seed delta triples
@@ -1832,14 +1928,17 @@ impl Reasoner {
         }
 
         // Non-destructive read of stable partitions (preserves Variable state for incremental use)
-        let stable = self.spo.stable.borrow();
         let mut output: Vec<KeyedTriple> = Vec::new();
-        for batch in stable.iter() {
-            output.extend(
-                batch.iter()
-                    .filter(|(s, (p, o))| *s > 0 && *p > 0 && *o > 0)
-            );
+        {
+            let stable = self.spo.stable.borrow();
+            for batch in stable.iter() {
+                output.extend(
+                    batch.iter()
+                        .filter(|(s, (p, o))| *s > 0 && *p > 0 && *o > 0)
+                );
+            }
         }
+        self.detect_rdfs_datatype_inconsistencies(&output);
         // Build oxrdf output
         let mut out_triples: Vec<Triple> = Vec::with_capacity(output.len());
         for &(_s, (_p, _o)) in output.iter() {
@@ -1918,6 +2017,102 @@ impl Reasoner {
             })
             .collect()
     }
+}
+
+fn is_rdf_container_membership_property_iri(iri: &str) -> bool {
+    const RDF_CONTAINER_PREFIX: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#_";
+    let Some(suffix) = iri.strip_prefix(RDF_CONTAINER_PREFIX) else {
+        return false;
+    };
+    !suffix.is_empty()
+        && suffix.chars().all(|c| c.is_ascii_digit())
+        && suffix.parse::<u64>().ok().is_some_and(|n| n > 0)
+}
+
+fn integer_lexical_is_valid(value: &str) -> bool {
+    if value.is_empty() {
+        return false;
+    }
+    let mut chars = value.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    let digits_only = if first == '+' || first == '-' {
+        chars.collect::<String>()
+    } else {
+        value.to_string()
+    };
+    !digits_only.is_empty() && digits_only.chars().all(|c| c.is_ascii_digit())
+}
+
+fn int_lexical_is_valid(value: &str) -> bool {
+    integer_lexical_is_valid(value) && value.parse::<i32>().is_ok()
+}
+
+fn xml_literal_lexical_is_well_formed(value: &str) -> bool {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return true;
+    }
+    if !trimmed.contains('<') {
+        return true;
+    }
+    if !trimmed.starts_with('<') || !trimmed.ends_with('>') {
+        return false;
+    }
+    if trimmed == "<" || trimmed == ">" {
+        return false;
+    }
+    trimmed.ends_with("/>") || trimmed.contains("</")
+}
+
+fn literal_well_formed_for_datatype(literal: &oxrdf::Literal, datatype_iri: &str) -> Option<bool> {
+    const XSD_STRING: &str = "http://www.w3.org/2001/XMLSchema#string";
+    const XSD_INTEGER: &str = "http://www.w3.org/2001/XMLSchema#integer";
+    const XSD_INT: &str = "http://www.w3.org/2001/XMLSchema#int";
+    const RDF_LANG_STRING: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString";
+    const RDF_XML_LITERAL: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral";
+
+    let lexical = literal.value();
+    Some(match datatype_iri {
+        XSD_STRING => true,
+        XSD_INTEGER => integer_lexical_is_valid(lexical),
+        XSD_INT => int_lexical_is_valid(lexical),
+        RDF_LANG_STRING => literal.language().is_some(),
+        RDF_XML_LITERAL => xml_literal_lexical_is_well_formed(lexical),
+        _ => return None,
+    })
+}
+
+fn term_in_datatype_space(term: &Term, datatype_iri: &str) -> Option<bool> {
+    const XSD_STRING: &str = "http://www.w3.org/2001/XMLSchema#string";
+    const XSD_INTEGER: &str = "http://www.w3.org/2001/XMLSchema#integer";
+    const XSD_INT: &str = "http://www.w3.org/2001/XMLSchema#int";
+    const RDF_LANG_STRING: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString";
+    const RDF_XML_LITERAL: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral";
+
+    let Term::Literal(literal) = term else {
+        return Some(false);
+    };
+    let literal_datatype = literal.datatype().as_str();
+    Some(match datatype_iri {
+        XSD_STRING => literal.language().is_none() && literal_datatype == XSD_STRING,
+        XSD_INTEGER => match literal_datatype {
+            XSD_INTEGER => literal_well_formed_for_datatype(literal, XSD_INTEGER).unwrap_or(false),
+            XSD_INT => literal_well_formed_for_datatype(literal, XSD_INT).unwrap_or(false),
+            _ => false,
+        },
+        XSD_INT => {
+            literal_datatype == XSD_INT
+                && literal_well_formed_for_datatype(literal, XSD_INT).unwrap_or(false)
+        }
+        RDF_LANG_STRING => literal.language().is_some(),
+        RDF_XML_LITERAL => {
+            literal_datatype == RDF_XML_LITERAL
+                && literal_well_formed_for_datatype(literal, RDF_XML_LITERAL).unwrap_or(false)
+        }
+        _ => return None,
+    })
 }
 
 /**

--- a/lib/src/reasoner.rs
+++ b/lib/src/reasoner.rs
@@ -61,6 +61,8 @@ impl ReasoningError {
             "prp-asyp" => "OWLRL.PRP_ASYP",
             "prp-irp" => "OWLRL.PRP_IRP",
             "cls-com" => "OWLRL.CLS_COM",
+            "rdfs-datatype" => "RDFS.DATATYPE",
+            "rdfs-datatype-range" => "RDFS.DATATYPE_RANGE",
             _ => "OWLRL.UNKNOWN",
         }
         .to_string();

--- a/lib/src/tests.rs
+++ b/lib/src/tests.rs
@@ -1481,6 +1481,42 @@ fn test_rdfs_datatype_no_error_without_range_or_ill_formed() -> Result<(), Strin
     Ok(())
 }
 
+#[test]
+fn test_rdfs_datatype_diagnostic_code() -> Result<(), String> {
+    // Locks in the stable diagnostic code for the rdfs-datatype rule.
+    let mut r = Reasoner::new();
+    r.load_triples(vec![typed_literal_triple(
+        "urn:s", "urn:p", "abc", XSD_INTEGER,
+    )]);
+    r.reason();
+    let has_code = r
+        .errors()
+        .iter()
+        .any(|e| e.code() == "RDFS.DATATYPE" && e.rule() == "rdfs-datatype");
+    assert!(has_code, "expected diagnostic with code RDFS.DATATYPE and rule rdfs-datatype");
+    Ok(())
+}
+
+#[test]
+fn test_rdfs_datatype_range_diagnostic_code() -> Result<(), String> {
+    // Locks in the stable diagnostic code for the rdfs-datatype-range rule.
+    let mut r = Reasoner::new();
+    r.load_triples_str(vec![("urn:p", RDFS_RANGE, XSD_INTEGER)]);
+    r.load_triples(vec![typed_literal_triple(
+        "urn:s", "urn:p", "abc", XSD_STRING,
+    )]);
+    r.reason();
+    let has_code = r
+        .errors()
+        .iter()
+        .any(|e| e.code() == "RDFS.DATATYPE_RANGE" && e.rule() == "rdfs-datatype-range");
+    assert!(
+        has_code,
+        "expected diagnostic with code RDFS.DATATYPE_RANGE and rule rdfs-datatype-range"
+    );
+    Ok(())
+}
+
 //#[test]
 //fn test_triple_update1() -> Result<(), String> {
 //    let mut u = TripleUpdate::new();

--- a/lib/src/tests.rs
+++ b/lib/src/tests.rs
@@ -13,6 +13,14 @@ const RDF_TYPE: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
 const RDF_FIRST: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#first";
 const RDF_REST: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#rest";
 const RDF_NIL: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#nil";
+const RDF_PROPERTY: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property";
+const RDF_XML_LITERAL: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral";
+const RDFS_MEMBER: &str = "http://www.w3.org/2000/01/rdf-schema#member";
+const RDFS_CONTAINER_MEMBERSHIP_PROPERTY: &str =
+    "http://www.w3.org/2000/01/rdf-schema#ContainerMembershipProperty";
+const XSD_STRING: &str = "http://www.w3.org/2001/XMLSchema#string";
+const XSD_INTEGER: &str = "http://www.w3.org/2001/XMLSchema#integer";
+const XSD_INT: &str = "http://www.w3.org/2001/XMLSchema#int";
 const OWL_SAMEAS: &str = "http://www.w3.org/2002/07/owl#sameAs";
 const OWL_EQUIVALENTCLASS: &str = "http://www.w3.org/2002/07/owl#equivalentClass";
 const OWL_HASVALUE: &str = "http://www.w3.org/2002/07/owl#hasValue";
@@ -1086,6 +1094,390 @@ fn test_scm_eqc_with_instances() -> Result<(), String> {
         wrap!(RDF_TYPE),
         "<urn:A>".to_string()
     )));
+    Ok(())
+}
+
+// ==================== RDFS container/datatype entailment tests ====================
+//
+// Tests for the container-membership-property axiomatisation and the
+// datatype well-formedness / range-clash diagnostics introduced in
+// commit 8f866a5 ("reasonable: add rdfs container/datatype entailment fixes
+// for W3C tests").
+//
+// W3C RDF Semantics test cross-reference:
+//   https://github.com/w3c/rdf-tests/tree/main/rdf/rdf11/rdf-mt
+//   - rdfms-seq-representation-test002 / -test003 / -test004
+//   - rdfs-container-membership-superProperty-test001
+//   - xmlsch-02-whitespace-facet-1 / -2 / -4
+//   - rdfms-xmllang-test007a / b / c
+//   - pfps-10-non-well-formed-literal-1
+
+/// Build an oxrdf Triple with a typed literal object.
+fn typed_literal_triple(s: &str, p: &str, value: &str, datatype: &str) -> oxrdf::Triple {
+    use crate::common::make_triple;
+    make_triple(
+        oxrdf::Term::NamedNode(oxrdf::NamedNode::new(s).unwrap()),
+        oxrdf::Term::NamedNode(oxrdf::NamedNode::new(p).unwrap()),
+        oxrdf::Term::Literal(oxrdf::Literal::new_typed_literal(
+            value,
+            oxrdf::NamedNode::new(datatype).unwrap(),
+        )),
+    )
+    .unwrap()
+}
+
+/// Build an oxrdf Triple with a language-tagged literal object.
+fn lang_literal_triple(s: &str, p: &str, value: &str, language: &str) -> oxrdf::Triple {
+    use crate::common::make_triple;
+    make_triple(
+        oxrdf::Term::NamedNode(oxrdf::NamedNode::new(s).unwrap()),
+        oxrdf::Term::NamedNode(oxrdf::NamedNode::new(p).unwrap()),
+        oxrdf::Term::Literal(oxrdf::Literal::new_language_tagged_literal_unchecked(
+            value, language,
+        )),
+    )
+    .unwrap()
+}
+
+#[test]
+fn test_rdfs_container_membership_axioms() -> Result<(), String> {
+    // W3C rdf-mt: rdfms-seq-representation-test002 and test004.
+    // Any triple using rdf:_N (N>0) as predicate must axiomatically entail:
+    //   rdf:_N rdf:type rdfs:ContainerMembershipProperty
+    //   rdf:_N rdfs:subPropertyOf rdfs:member
+    //   rdf:_N rdf:type rdf:Property
+    let mut r = Reasoner::new();
+    r.load_triples_str(vec![(
+        "http://example.org/foo",
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#_1",
+        "http://example.org/bar",
+    )]);
+    r.reason();
+    let res = r.get_triples_string();
+    let rdf_n1 = "<http://www.w3.org/1999/02/22-rdf-syntax-ns#_1>".to_string();
+    // test002 conclusion: rdf:_1 rdf:type rdfs:ContainerMembershipProperty
+    assert!(
+        res.contains(&(
+            rdf_n1.clone(),
+            wrap!(RDF_TYPE),
+            wrap!(RDFS_CONTAINER_MEMBERSHIP_PROPERTY)
+        )),
+        "expected rdf:_1 rdf:type rdfs:ContainerMembershipProperty (W3C rdfms-seq-representation-test002)"
+    );
+    // test004 conclusion: rdf:_1 rdfs:subPropertyOf rdfs:member
+    assert!(
+        res.contains(&(rdf_n1.clone(), wrap!(RDFS_SUBPROP), wrap!(RDFS_MEMBER))),
+        "expected rdf:_1 rdfs:subPropertyOf rdfs:member (W3C rdfms-seq-representation-test004)"
+    );
+    // RDF axiomatic: rdf:_1 rdf:type rdf:Property
+    assert!(
+        res.contains(&(rdf_n1, wrap!(RDF_TYPE), wrap!(RDF_PROPERTY))),
+        "expected rdf:_1 rdf:type rdf:Property (RDF axiomatic triple)"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_rdfs_container_membership_entails_member() -> Result<(), String> {
+    // W3C rdf-mt: rdfms-seq-representation-test003.
+    // <a> rdf:_1 <b>  =>  <a> rdfs:member <b>
+    // (via rdf:_1 rdfs:subPropertyOf rdfs:member and prp-spo1)
+    let mut r = Reasoner::new();
+    r.load_triples_str(vec![(
+        "http://example.org/a",
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#_1",
+        "http://example.org/b",
+    )]);
+    r.reason();
+    let res = r.get_triples_string();
+    assert!(
+        res.contains(&(
+            "<http://example.org/a>".to_string(),
+            wrap!(RDFS_MEMBER),
+            "<http://example.org/b>".to_string()
+        )),
+        "expected <a> rdfs:member <b> (W3C rdfms-seq-representation-test003)"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_rdfs_container_membership_multiple_indices() -> Result<(), String> {
+    // Axioms must fire for every distinct rdf:_N (N>0) predicate observed.
+    let mut r = Reasoner::new();
+    r.load_triples_str(vec![
+        ("urn:s", "http://www.w3.org/1999/02/22-rdf-syntax-ns#_1", "urn:o1"),
+        ("urn:s", "http://www.w3.org/1999/02/22-rdf-syntax-ns#_2", "urn:o2"),
+        ("urn:s", "http://www.w3.org/1999/02/22-rdf-syntax-ns#_42", "urn:o42"),
+    ]);
+    r.reason();
+    let res = r.get_triples_string();
+    for n in &[1u32, 2, 42] {
+        let rdf_n = format!("<http://www.w3.org/1999/02/22-rdf-syntax-ns#_{}>", n);
+        assert!(
+            res.contains(&(
+                rdf_n.clone(),
+                wrap!(RDFS_SUBPROP),
+                wrap!(RDFS_MEMBER)
+            )),
+            "missing rdf:_{} rdfs:subPropertyOf rdfs:member axiom",
+            n
+        );
+        let o = format!("<urn:o{}>", n);
+        assert!(
+            res.contains(&("<urn:s>".to_string(), wrap!(RDFS_MEMBER), o)),
+            "missing urn:s rdfs:member urn:o{} entailment",
+            n
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn test_rdfs_container_membership_ignores_non_numeric_and_zero() -> Result<(), String> {
+    // rdf:_abc, rdf:_0, and bare rdf:_ are NOT container membership properties.
+    // (The detector requires a strictly-positive integer suffix.)
+    let mut r = Reasoner::new();
+    r.load_triples_str(vec![
+        ("urn:s", "http://www.w3.org/1999/02/22-rdf-syntax-ns#_abc", "urn:o"),
+        ("urn:s", "http://www.w3.org/1999/02/22-rdf-syntax-ns#_0", "urn:o2"),
+        ("urn:s", "http://www.w3.org/1999/02/22-rdf-syntax-ns#_", "urn:o3"),
+    ]);
+    r.reason();
+    let res = r.get_triples_string();
+    for suffix in &["_abc", "_0", "_"] {
+        let p = format!("<http://www.w3.org/1999/02/22-rdf-syntax-ns#{}>", suffix);
+        assert!(
+            !res.contains(&(
+                p.clone(),
+                wrap!(RDF_TYPE),
+                wrap!(RDFS_CONTAINER_MEMBERSHIP_PROPERTY)
+            )),
+            "rdf:{} should not be a ContainerMembershipProperty",
+            suffix
+        );
+        assert!(
+            !res.contains(&(p, wrap!(RDFS_SUBPROP), wrap!(RDFS_MEMBER))),
+            "rdf:{} should not be subPropertyOf rdfs:member",
+            suffix
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn test_rdfs_container_membership_super_property_negative() -> Result<(), String> {
+    // W3C rdf-mt: rdfs-container-membership-superProperty-test001 (NegativeEntailmentTest).
+    // <s> rdfs:member <o> does NOT entail <s> rdf:_N <o> for any N.
+    // i.e. the rule fires only in the direction rdf:_N -> rdfs:member.
+    let mut r = Reasoner::new();
+    r.load_triples_str(vec![(
+        "http://example/stuff#something",
+        RDFS_MEMBER,
+        "http://example/stuff#somethingElse",
+    )]);
+    r.reason();
+    let res = r.get_triples_string();
+    // No rdf:_N triple should appear with these endpoints.
+    for n in 1..5 {
+        let rdf_n = format!("<http://www.w3.org/1999/02/22-rdf-syntax-ns#_{}>", n);
+        assert!(
+            !res.contains(&(
+                "<http://example/stuff#something>".to_string(),
+                rdf_n.clone(),
+                "<http://example/stuff#somethingElse>".to_string()
+            )),
+            "rdfs:member should not entail rdf:_{} (W3C rdfs-container-membership-superProperty-test001)",
+            n
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn test_rdfs_datatype_ill_formed_xsd_int_with_whitespace() -> Result<(), String> {
+    // W3C rdf-mt: xmlsch-02-whitespace-facet-2 / -4.
+    // " 3 "^^xsd:int has leading/trailing whitespace and is ill-formed.
+    // The reasoner should record an rdfs-datatype diagnostic.
+    let mut r = Reasoner::new();
+    r.load_triples(vec![typed_literal_triple(
+        "http://www.example.org/a",
+        "http://example.org/prop",
+        " 3 ",
+        XSD_INT,
+    )]);
+    r.reason();
+    assert!(
+        r.errors().iter().any(|e| e.rule() == "rdfs-datatype"),
+        "expected rdfs-datatype diagnostic for ill-formed xsd:int literal \" 3 \" (W3C xmlsch-02-whitespace-facet-2/-4)"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_rdfs_datatype_well_formed_xsd_int_no_error() -> Result<(), String> {
+    // W3C rdf-mt: xmlsch-02-whitespace-facet-1 premise (test001.ttl).
+    // "3"^^xsd:int is well-formed; no rdfs-datatype diagnostic should fire.
+    let mut r = Reasoner::new();
+    r.load_triples(vec![typed_literal_triple(
+        "http://www.example.org/a",
+        "http://example.org/prop",
+        "3",
+        XSD_INT,
+    )]);
+    r.reason();
+    assert!(
+        !r.errors().iter().any(|e| e.rule() == "rdfs-datatype"),
+        "no rdfs-datatype diagnostic should be raised for well-formed \"3\"^^xsd:int"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_rdfs_datatype_ill_formed_xsd_integer() -> Result<(), String> {
+    // "abc"^^xsd:integer has a non-numeric lexical form; ill-formed.
+    let mut r = Reasoner::new();
+    r.load_triples(vec![typed_literal_triple(
+        "urn:s", "urn:p", "abc", XSD_INTEGER,
+    )]);
+    r.reason();
+    assert!(
+        r.errors().iter().any(|e| e.rule() == "rdfs-datatype"),
+        "expected rdfs-datatype diagnostic for non-numeric xsd:integer literal"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_rdfs_datatype_well_formed_signed_xsd_integer() -> Result<(), String> {
+    // Signed integers ("+7", "-42") are well-formed lexical forms for xsd:integer.
+    let mut r = Reasoner::new();
+    r.load_triples(vec![
+        typed_literal_triple("urn:s", "urn:p", "-42", XSD_INTEGER),
+        typed_literal_triple("urn:s", "urn:p", "+7", XSD_INTEGER),
+    ]);
+    r.reason();
+    assert!(
+        !r.errors().iter().any(|e| e.rule() == "rdfs-datatype"),
+        "signed xsd:integer literals (-42, +7) should be well-formed"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_rdfs_datatype_xsd_int_overflow() -> Result<(), String> {
+    // xsd:int is 32-bit; a value outside i32 range is ill-formed.
+    let mut r = Reasoner::new();
+    r.load_triples(vec![typed_literal_triple(
+        "urn:s",
+        "urn:p",
+        "99999999999999999999",
+        XSD_INT,
+    )]);
+    r.reason();
+    assert!(
+        r.errors().iter().any(|e| e.rule() == "rdfs-datatype"),
+        "expected rdfs-datatype diagnostic for xsd:int literal outside i32 range"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_rdfs_datatype_ill_formed_xml_literal() -> Result<(), String> {
+    // An rdf:XMLLiteral whose lexical form does not close its single open tag
+    // is ill-formed.
+    let mut r = Reasoner::new();
+    r.load_triples(vec![typed_literal_triple(
+        "urn:s",
+        "urn:p",
+        "<unclosed",
+        RDF_XML_LITERAL,
+    )]);
+    r.reason();
+    assert!(
+        r.errors().iter().any(|e| e.rule() == "rdfs-datatype"),
+        "expected rdfs-datatype diagnostic for ill-formed rdf:XMLLiteral"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_rdfs_datatype_range_clash_string_for_integer() -> Result<(), String> {
+    // Predicate range is xsd:integer; object is "abc"^^xsd:string. Range clash.
+    let mut r = Reasoner::new();
+    r.load_triples_str(vec![("urn:p", RDFS_RANGE, XSD_INTEGER)]);
+    r.load_triples(vec![typed_literal_triple(
+        "urn:s", "urn:p", "abc", XSD_STRING,
+    )]);
+    r.reason();
+    assert!(
+        r.errors()
+            .iter()
+            .any(|e| e.rule() == "rdfs-datatype-range"),
+        "expected rdfs-datatype-range diagnostic when object's datatype is not in range"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_rdfs_datatype_range_compatible_integer() -> Result<(), String> {
+    // Predicate range is xsd:integer; both xsd:integer and xsd:int objects
+    // are inside the value space of xsd:integer (xsd:int ⊂ xsd:integer).
+    let mut r = Reasoner::new();
+    r.load_triples_str(vec![("urn:p", RDFS_RANGE, XSD_INTEGER)]);
+    r.load_triples(vec![
+        typed_literal_triple("urn:s", "urn:p", "42", XSD_INTEGER),
+        typed_literal_triple("urn:s2", "urn:p", "7", XSD_INT),
+    ]);
+    r.reason();
+    assert!(
+        !r.errors()
+            .iter()
+            .any(|e| e.rule() == "rdfs-datatype-range"),
+        "xsd:integer and xsd:int literals should both satisfy range xsd:integer"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_rdfs_datatype_range_clash_langstring_for_string() -> Result<(), String> {
+    // W3C rdf-mt: rdfms-xmllang-test007a (plain string vs language-tagged).
+    // Predicate range is xsd:string; object is "chat"@fr (rdf:langString) →
+    // range clash, because a language-tagged literal is not in xsd:string's
+    // value space.
+    let mut r = Reasoner::new();
+    r.load_triples_str(vec![("http://example.org/property", RDFS_RANGE, XSD_STRING)]);
+    r.load_triples(vec![lang_literal_triple(
+        "http://example.org/node",
+        "http://example.org/property",
+        "chat",
+        "fr",
+    )]);
+    r.reason();
+    assert!(
+        r.errors()
+            .iter()
+            .any(|e| e.rule() == "rdfs-datatype-range"),
+        "expected rdfs-datatype-range diagnostic when xsd:string range receives rdf:langString"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_rdfs_datatype_no_error_without_range_or_ill_formed() -> Result<(), String> {
+    // Sanity: a well-formed literal whose predicate has no rdfs:range
+    // and whose datatype is recognised produces no diagnostics.
+    let mut r = Reasoner::new();
+    r.load_triples(vec![typed_literal_triple(
+        "urn:s", "urn:p", "42", XSD_INTEGER,
+    )]);
+    r.reason();
+    assert!(
+        !r.errors()
+            .iter()
+            .any(|e| e.rule() == "rdfs-datatype" || e.rule() == "rdfs-datatype-range"),
+        "a well-formed literal with no range constraint should not raise datatype diagnostics"
+    );
     Ok(())
 }
 


### PR DESCRIPTION
I'm working on a Rust based SPARQL query [CLI tool](https://github.com/decisym/de) built around the [HDT](https://github.com/KonradHoeffner/hdt) crate. Looking to mimic the robustness testing done as part of [oxigraph](https://github.com/oxigraph/oxigraph/tree/main/testsuite)'s testing, we used the W3C test suite available [here](https://github.com/w3c/rdf-tests) for conformance testing which ultimately led to investigating patches in the reasonable crate to support related failing test scenarios.

# Summary

Adds two RDFS entailment behaviors to the reasoner, aligned with the W3C RDF Semantics test suite ([rdf-tests/rdf/rdf11/rdf-mt](https://github.com/w3c/rdf-tests/tree/main/rdf/rdf11/rdf-mt)):

## 1. RDFS container membership property axiomatization. 
Before fixpoint, the reasoner now scans the input for any triple whose predicate matches rdf:_N (positive integer N) and injects the three axiomatic consequences:
  - `rdf:_N rdf:type rdf:Property`
  - `rdf:_N rdf:type rdfs:ContainerMembershipProperty`
  - `rdf:_N rdfs:subPropertyOf rdfs:member`

Injection runs inside reason() and dedupes against the existing input, so it is idempotent across full and incremental materialization. Once the `rdfs:subPropertyOf` `rdfs:member` axiom is in the closure, prp-spo1 propagates each `<s> rdf:_N <o>` to `<s> rdfs:member <o>` automatically. This covers [rdfms-seq-representation-test002/-test003/-test004](https://github.com/w3c/rdf-tests/tree/main/rdf/rdf11/rdf-mt/rdfms-seq-representation), and is consistent with the negative test [rdfs-container-membership-superProperty-test001](https://github.com/w3c/rdf-tests/tree/main/rdf/rdf11/rdf-mt/rdfs-container-membership-superProperty) (the rule only fires in the rdf:_N -> rdfs:member direction).

## 2. RDFS datatype well-formedness and range-clash diagnostics.
After fixpoint, a new pass walks the closure and emits structured diagnostics for:
 - rdfs-datatype: typed literals whose lexical form is outside their declared datatype's value space.
 - rdfs-datatype-range: object literals whose datatype is not in the value space declared by a predicate's `rdfs:range`.

Recognized datatypes: 
- `xsd:string`
- `xsd:integer` (incl. signed +/- prefixes)
- `xsd:int` (32-bit range)
- `rdf:langString` (must carry a language tag)
- `rdf:XMLLiteral` (basic well-formedness). 

Unrecognized datatypes are passed through silently - no false positives. Diagnostics are surfaced via the existing errors() / diagnostics() API and respect the configured collect_diagnostics, dedupe, and max_diagnostics options. This covers [xmlsch-02-whitespace-facet-1/2/4](https://github.com/w3c/rdf-tests/tree/main/rdf/rdf11/rdf-mt/xmlsch-02), and supports detection of the literal/range mismatches probed by the `rdfms-xmllang` family.

## Notes
- The closure-extraction block in reason() was scoped down so the read borrow of self.spo.stable releases before the new datatype scan needs &self.
- No public API additions; the new rules surface entirely through existing triple output and the existing diagnostics channel.

# AI Disclaimer
I didn't see any follow-ups to https://github.com/gtfierro/reasonable/issues/38, but figured I should clarify here. @donpellegrino's original commit was drafted using GPT's Codex and subsequent commits used Claude Opus 4.7