### PR TITLE
feat(rdf-12): add TermRef::Triple(_) arm for downstream coexistence

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -29,6 +29,13 @@ farmhash = { version = "1", optional = true }
 default = []
 # Opt-in to compile the legacy query module (pulls in rdf + friends)
 legacy-query = ["dep:regex", "dep:serde", "dep:serde_sexpr", "dep:farmhash"]
+# RDF 1.2 (RDF-star) coexistence: enables a feature-gated match arm
+# over `TermRef::Triple(_)` so `reasonable` compiles in workspaces that
+# pull in `oxrdf` with its `rdf-12` feature enabled (e.g., alongside
+# `shacl` 0.3.x via `rudof_rdf`). `reasonable` itself does not
+# implement RDF-star reasoning; the arm panics if a quoted-triple term
+# is encountered. Strictly additive when off.
+rdf-12 = ["oxrdf/rdf-12"]
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/lib/src/common.rs
+++ b/lib/src/common.rs
@@ -161,6 +161,23 @@ pub fn oxrdf_to_rio<'a>(t: TripleRef<'a>) -> rio::Triple<'a> {
                 }
             }
         }
+        // RDF 1.2 quoted-triple term, only present when oxrdf's `rdf-12`
+        // feature is enabled. `reasonable` does not implement RDF-star
+        // reasoning, and rio-api does not have an equivalent term shape
+        // today. This arm exists strictly so `reasonable` compiles in
+        // downstream workspaces where another crate hard-enables
+        // oxrdf's `rdf-12` feature (e.g., `shacl` 0.3.x via `rudof_rdf`
+        // 0.3.1). It is additive: when `rdf-12` is off, the variant
+        // does not exist and this arm is invisible.
+        //
+        // Behaviour mirrors the existing `panic!("no rdf*")` arms in
+        // `rio_to_oxrdf` above. If a future use case needs graceful
+        // handling, propose a separate API change returning
+        // `Option`/`Result` here.
+        #[cfg(feature = "rdf-12")]
+        TermRef::Triple(_) => panic!(
+            "reasonable: RDF 1.2 quoted triples are not supported; received `<<...>>` term"
+        ),
     };
     rio::Triple {
         subject: s,


### PR DESCRIPTION
## Problem

`oxrdf 0.3`'s `rdf-12` feature (opt-in) adds a `Triple` variant to `TermRef` for RDF 1.2 quoted triples (see [`oxrdf/src/triple.rs:176`](https://github.com/oxigraph/oxigraph/blob/main/lib/oxrdf/src/triple.rs#L176) and [`:208`](https://github.com/oxigraph/oxigraph/blob/main/lib/oxrdf/src/triple.rs#L208)).

Several downstream crates hard-enable that feature — most notably `shacl 0.3.x` (the consolidated SHACL crate released as part of [`rudof 0.3.1`](https://github.com/rudof-project/rudof/releases/tag/v0.3.1) on 2026-05-12), reached transitively via [`rudof_rdf 0.3.1`'s workspace Cargo.toml lines 284-294](https://github.com/rudof-project/rudof) (`oxrdf` declared with `features = ["rdf-12"]`, non-optional).

When a downstream workspace pulls both `reasonable` and any of those crates, Cargo's feature unification enables `rdf-12` on the workspace's shared `oxrdf` resolution. `reasonable`'s `oxrdf_to_rio` match in [`lib/src/common.rs:140`](lib/src/common.rs#L140) is non-exhaustive over the new variant, producing:

```
error[E0004]: non-exhaustive patterns: `&TermRef::Triple(_)` not covered
 --> lib/src/common.rs:140:21
```

This blocks pgRDF ([styk-tv/pgRDF](https://github.com/styk-tv/pgRDF)) — and presumably other downstream consumers — from combining OWL 2 RL reasoning (`reasonable`) with W3C SHACL Core validation (`shacl 0.3.x`) in one workspace.

## Patch

Two changes, both strictly additive:

1. **New `rdf-12` feature in `reasonable/lib/Cargo.toml`** that forwards to `oxrdf/rdf-12`. Downstream workspaces that already pull in `rdf-12` via another crate opt into this passthrough feature explicitly:
   ```toml
   reasonable = { version = "0.4", features = ["rdf-12"] }
   ```

2. **Feature-gated match arm in `lib/src/common.rs`** covering `TermRef::Triple(_)`. The arm panics with a clear message, mirroring the existing `panic!("no rdf*")` arms in `rio_to_oxrdf` (line 103 and line 127) for unsupported variants.

`reasonable` does not implement RDF-star reasoning today and `rio-api` has no equivalent term shape, so panicking surfaces unsupported input early at the call site.

## Why panic vs return Result

The current `oxrdf_to_rio` signature is infallible:

```rust
pub fn oxrdf_to_rio<'a>(t: TripleRef<'a>) -> rio::Triple<'a>
```

Returning `Result<rio::Triple, _>` would be a breaking change to every call site. The conservative minimal-diff approach is to panic on unsupported input, which matches the existing local idiom (`panic!("no rdf*")` is already used twice in the same file for the same conceptual case).

If a future use case requires graceful handling of quoted triples (e.g., skipping them during forward-chaining), a follow-up PR can introduce the fallible signature as a major-version change.

## Compatibility

- **Strictly additive when `rdf-12` is off** — no observable change for current users. The arm and the feature are invisible.
- **When `rdf-12` is on** — workspaces that fed quoted triples to `oxrdf_to_rio` previously got a compile error from non-exhaustive matching; now they get the crate compiling and a clear runtime panic at the call site if such a term ever reaches the function. Either way those workspaces had to resolve the issue — this PR just makes them compile and surfaces the unsupported input.

## Verification

Verified locally on commit [`8974c11`](https://github.com/styk-tv/reasonable/commit/8974c11) of branch [`rdf12-passthrough`](https://github.com/styk-tv/reasonable/tree/rdf12-passthrough):

| Command | Result |
|---|---|
| `cargo check` (default features) | clean |
| `cargo check -p reasonable --features rdf-12` | clean |
| `cargo test -p reasonable` (default) | 73 unit + 8 doc tests pass, 0 failed, 1 ignored |
| `cargo test -p reasonable --features rdf-12` | 73 unit + 8 doc tests pass, 0 failed, 1 ignored |

## Downstream context

This PR was prepared by pgRDF ([styk-tv/pgRDF](https://github.com/styk-tv/pgRDF)), which needs to ship `pgrdf.validate()` (SHACL Core validation via `shacl 0.3.x`) alongside `pgrdf.materialize()` (OWL 2 RL inference via `reasonable`). pgRDF has the real SHACL impl shipped on `main` (commit [`ac40bc2`](https://github.com/styk-tv/pgRDF/commit/ac40bc2)); this PR unblocks the stock-dep path for everyone — pgRDF currently composes the fix via `[patch.crates-io]` pointing at the fork branch, and other downstream consumers combining `reasonable` with any `rudof 0.3.x` / `shacl 0.3.x` workspace hit the same compile error.

Once this lands upstream, pgRDF will drop its `[patch.crates-io]` override and pin the released `reasonable` version directly. pgRDF tracks the patch + close-out in [`specs/ERRATA.v0.4.md` entry E-011](https://github.com/styk-tv/pgRDF/blob/main/specs/ERRATA.v0.4.md).

## Verified downstream

The patched fork is wired into pgRDF via `[patch.crates-io]` in commit [`ac40bc2`](https://github.com/styk-tv/pgRDF/commit/ac40bc2). The full pgRDF test bar passes against the patched dep tree:

| Layer | Count | Result |
|---|---|---|
| `cargo pgrx test pg17` | 94 | pass / 0 fail |
| `just test-regression` (pg_regress) | 40 | pass / 0 fail |
| `just test-w3c` (W3C-shape SPARQL) | 23 | pass / 0 fail |
| `just test-lubm` (LUBM-shape) | 3 | pass / 0 fail |
| **Total** | **160** | **all green** |

Real SHACL Core validation works against `sh:NodeShape` + `sh:property` + `sh:class` / `sh:datatype` constraints. Sample violation output from `tests/regression/sql/71-shacl-real.sql` (Alice missing required `ex:age`):

```json
{
  "conforms": false,
  "results": [{
    "focusNode": "http://example.org/alice",
    "resultPath": "http://example.org/age",
    "sourceShape": "_:b887c79907df332dbd793b0bc80edbd5",
    "resultMessage": "MinCount(1) not satisfied",
    "resultSeverity": "sh:Violation",
    "sourceConstraintComponent": "http://www.w3.org/ns/shacl#MinCountConstraintComponent",
    "value": null
  }],
  "data_graph_id": 8971,
  "shapes_graph_id": 8972,
  "data_triples": 5,
  "shapes_triples": 10,
  "elapsed_ms": 1.68
}
```

`cargo check --no-default-features --features pg17` on the pgRDF workspace is clean with `shacl 0.3.1` + `rudof_rdf 0.3.1` + the patched `reasonable` resolved via `[patch.crates-io]`.

## Test plan

- [x] `cargo check` clean with `rdf-12` enabled in workspace (confirmed via pgRDF — `cargo check --features pg17` clean)
- [x] `cargo check` clean with `rdf-12` off (no regression on stand-alone `reasonable`)
- [x] `cargo test -p reasonable` existing suite passes in both feature configurations (73 unit + 8 doc, 0 fail)
- [x] Downstream pgRDF workspace builds with `shacl 0.3.1` + `reasonable` (this branch) via `[patch.crates-io]`
- [x] Downstream SHACL real-impl produces correct violation reports (pgRDF `tests/regression/sql/71-shacl-real.sql` green; `sh:Violation` shape matches the W3C `sh:ValidationReport` skeleton)
- [ ] (Optional) Add a `#[cfg(feature = "rdf-12")]` test in `reasonable` that constructs a quoted-triple `TermRef::Triple` and verifies the panic message. Held out of this PR to keep the diff minimal — happy to add if requested.

Thanks for reviewing.
