### PR TITLE
Fix 0.4.2 release: bump workspace version and skip PyPy wheels in wheel2deb

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -291,9 +291,9 @@ jobs:
 
           mkdir -p dist/python_deb dist/wheel2deb
 
-          wheels=(dist/wheels/*.whl)
+          wheels=(dist/wheels/*-cp*.whl)
           if [ ${#wheels[@]} -eq 0 ]; then
-            echo "No linux wheels found in dist/wheels" >&2
+            echo "No CPython linux wheels found in dist/wheels" >&2
             exit 1
           fi
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Gabe Fierro <gtfierro@mines.edu>"]
 repository = "https://github.com/gtfierro/reasonable"
 homepage = "https://brickschema.org/"
@@ -26,7 +26,7 @@ datafrog = "2.0.1"
 disjoint-sets = "0.4.2"
 log = "0.4"
 env_logger = "0.11"
-reasonable = { path = "lib", version = "0.4.1" }
+reasonable = { path = "lib", version = "0.4.2" }
 clap = { version = "4.3.10", features = ["derive"] }
 
 [profile.release]


### PR DESCRIPTION

- Bump workspace version from 0.4.1 to 0.4.2 so the publish workflow accepts the release
- Restrict the wheel2deb glob to CPython wheels (*-cp*) since wheel2deb skips PyPy wheels and produced 0 .deb packages, failing the existence check

Fixes #53