### PR TITLE
Run wheel2deb via uvx with click injected

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -263,6 +263,11 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
       - name: Download linux wheel artifacts
         uses: actions/download-artifact@v4
         with:
@@ -274,11 +279,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y apt-file dpkg-dev fakeroot build-essential devscripts debhelper
-
-      - name: Install wheel2deb
-        run: |
-          python -m pip install --upgrade pip
-          pip install wheel2deb
 
       - name: Update apt-file cache
         run: sudo apt-file update
@@ -303,7 +303,9 @@ jobs:
             rm -rf "$work"
             mkdir -p "$work"
             cp "$wheel" "$work/"
-            (cd "$work" && wheel2deb)
+            # wheel2deb 0.9.5 imports click but doesn't declare it as a
+            # dependency, so we inject it via uvx --with.
+            (cd "$work" && uvx --with click wheel2deb)
             if compgen -G "$work/output/*.deb" > /dev/null; then
               for deb in "$work"/output/*.deb; do
                 base="$(basename "$deb")"


### PR DESCRIPTION
wheel2deb 0.9.5 imports click directly but only declares typer as a dep, and recent typer releases stopped pulling click transitively, so the release job failed with ModuleNotFoundError: No module named 'click'.

Switch to uvx --with click wheel2deb: it runs wheel2deb in an isolated, cached env and explicitly layers click on top of its declared deps. This also lets us drop the separate Install wheel2deb step.