### PR TITLE
bump quick-xml for security patch

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -17,7 +17,7 @@ datafrog.workspace = true
 disjoint-sets.workspace = true
 log.workspace = true
 thiserror = "1.0"
-quick-xml = "0.41"
+quick-xml = "0.42"
 
 [features]
 default = []

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -17,7 +17,7 @@ datafrog.workspace = true
 disjoint-sets.workspace = true
 log.workspace = true
 thiserror = "1.0"
-quick-xml = "0.36"
+quick-xml = "0.41"
 
 [features]
 default = []


### PR DESCRIPTION
```bash
cargo audit

...

Crate:     quick-xml
Version:   0.36.2
Title:     Unbounded namespace-declaration allocation in `NsReader` enables memory-exhaustion denial of service
Date:      2026-06-29
ID:        RUSTSEC-2026-0195
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0195
Severity:  7.5 (high)
Solution:  Upgrade to >=0.41.0
Dependency tree:
quick-xml 0.36.2
└── reasonable 0.4.4
    ├── reasonable-cli 0.4.4
    └── pyreasonable 0.4.4

Crate:     quick-xml
Version:   0.36.2
Title:     Quadratic run time when checking a start tag for duplicate attribute names
Date:      2026-06-29
ID:        RUSTSEC-2026-0194
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0194
Severity:  7.5 (high)
Solution:  Upgrade to >=0.41.0
```